### PR TITLE
feature/result | poll/result 수정 및 타입 오류 해결

### DIFF
--- a/src/controller/poll/controller.ts
+++ b/src/controller/poll/controller.ts
@@ -6,6 +6,7 @@ import RestaurantService from '../../service/restaurant.service';
 import ParticipantService from '../../service/participant.service';
 import CreateParticipantInput from '../../type/participant/create.input';
 import CreatePollInput from '../../type/poll/create.input';
+import ResultRestaurant from '../../type/restaurant/result';
 import { BadRequestError, UnauthorizedError } from '../../util/customErrors';
 import Restaurant from '../../entity/restaurant.entity';
 import FilterInput from '../../type/filter/create.input';
@@ -183,18 +184,24 @@ export const getPollResultById: RequestHandler = async (req, res, next) => {
       (resolvedVoteCounts) => Math.max(...resolvedVoteCounts),
     );
 
-    // 최다 득표 restaurants(공동 1위 가능)
-    let restaurants: Restaurant[] = [];
-
     const resolvedVoteCounts = await Promise.all(voteCounts); // Promise 풀어주기
+
+    // 최다 득표 restaurants(공동 1위 가능)
+    let resultRestaurants: ResultRestaurant[] = [];
 
     resolvedVoteCounts.forEach((voteCount, index) => {
       if (voteCount === maxVoteCount) {
-        restaurants.push(candidates[index].restaurant);
+        const curRestaurant = candidates[index].restaurant;
+        resultRestaurants.push({
+          id: curRestaurant.id,
+          restaurantName: curRestaurant.restaurantName,
+          imgDir: curRestaurant.imgDir,
+          description: curRestaurant.description,
+        });
       }
     });
 
-    res.status(201).json(restaurants);
+    res.status(201).json({ maxVoteCount, resultRestaurants });
   } catch (error) {
     next(error);
   }

--- a/src/type/poll/create.input.ts
+++ b/src/type/poll/create.input.ts
@@ -2,7 +2,7 @@ import User from '../../entity/user.entity';
 
 export default interface CreatePollInput {
   pollName: string;
-  createdUser: Number;
+  createdUser: User;
   url?: string;
   createdAt: Date;
   endedAt?: Date;

--- a/src/type/restaurant/result.ts
+++ b/src/type/restaurant/result.ts
@@ -1,0 +1,6 @@
+export default interface ResultRestaurant {
+  id: number;
+  restaurantName: string;
+  imgDir?: string;
+  description: string;
+}


### PR DESCRIPTION
### 변경점
- 프론트의 투표 결과 페이지에서, 각 식당(최다 득표 식당)마다 필요한 정보는 `식당 id`, `식당 이름`, `식당 이미지 경로`, `식당 설명`입니다. 이에 따라 백에서도 식당 객체를 전부 넘겨주는 것이 아닌, 위의 필요한 정보만 넘겨줄 수 있도록 `type/restaurant/result.ts`를 추가했습니다. 
- `controller/poll/controller.ts`의 poll result 부분을 상술한 내용에 맞게 고쳐주었습니다. 
- 또한 `type/poll/create.input.ts`에서 `createdUser`의 타입이 `Number`로 되어 있어 계속 오류가 발생했는데 이 부분을 수정했습니다. hmin27 ^^